### PR TITLE
PAPP-38109: harden Censys result handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2016-2025 Splunk Inc.
+   Copyright (c) 2016-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Censys
-Copyright (c) 2016-2025 Splunk Inc.
+Copyright (c) 2016-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Censys
 
-Publisher: Splunk \
-Connector Version: 2.2.4 \
-Product Vendor: Censys, Inc. \
-Product Name: Censys \
+Publisher: Splunk <br>
+Connector Version: 2.2.4 <br>
+Product Vendor: Censys, Inc. <br>
+Product Name: Censys <br>
 Minimum Product Version: 6.1.1
 
 This app implements investigative actions to get information from the Censys search engine
@@ -40,19 +40,19 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate connectivity to Censys \
-[lookup certificate](#action-lookup-certificate) - Lookup certificate info \
-[lookup ip](#action-lookup-ip) - Lookup IP info \
-[lookup domain](#action-lookup-domain) - Lookup Domain info \
-[query domain](#action-query-domain) - Query the domain dataset \
-[query certificate](#action-query-certificate) - Query the certificate dataset \
+[test connectivity](#action-test-connectivity) - Validate connectivity to Censys <br>
+[lookup certificate](#action-lookup-certificate) - Lookup certificate info <br>
+[lookup ip](#action-lookup-ip) - Lookup IP info <br>
+[lookup domain](#action-lookup-domain) - Lookup Domain info <br>
+[query domain](#action-query-domain) - Query the domain dataset <br>
+[query certificate](#action-query-certificate) - Query the certificate dataset <br>
 [query ip](#action-query-ip) - Query the IP dataset
 
 ## action: 'test connectivity'
 
 Validate connectivity to Censys
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -67,7 +67,7 @@ No Output
 
 Lookup certificate info
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -257,7 +257,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Lookup IP info
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -484,7 +484,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Lookup Domain info
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -770,7 +770,7 @@ summary.total_objects_successful | numeric | | |
 
 Query the domain dataset
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -796,7 +796,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Query the certificate dataset
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -827,7 +827,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Query the IP dataset
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -881,7 +881,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -351,7 +351,6 @@ action_result.data.\*.result.services.\*.http.response.headers.\_encoding.Last_M
 action_result.data.\*.result.services.\*.http.response.headers.\_encoding.Location | string | | DISPLAY_UTF8 |
 action_result.data.\*.result.services.\*.http.response.headers.\_encoding.Referrer_Policy | string | | DISPLAY_UTF8 |
 action_result.data.\*.result.services.\*.http.response.headers.\_encoding.Server | string | | DISPLAY_UTF8 |
-action_result.data.\*.result.services.\*.http.response.headers.\_encoding.Set_Cookie | string | | DISPLAY_UTF8 |
 action_result.data.\*.result.services.\*.http.response.headers.\_encoding.Vary | string | | DISPLAY_UTF8 |
 action_result.data.\*.result.services.\*.http.response.headers.\_encoding.X_Content_Type_Options | string | | DISPLAY_UTF8 |
 action_result.data.\*.result.services.\*.http.response.headers.\_encoding.X_Frame_Options | string | | DISPLAY_UTF8 |

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/censys.json
+++ b/censys.json
@@ -19,7 +19,7 @@
     "latest_tested_versions": [
         "Cloud v2 API tested 20 June 2023"
     ],
-    "license": "Copyright (c) 2016-2025 Splunk Inc.",
+    "license": "Copyright (c) 2016-2026 Splunk Inc.",
     "configuration": {
         "api_id": {
             "description": "API ID",

--- a/censys.json
+++ b/censys.json
@@ -1752,13 +1752,6 @@
                     ]
                 },
                 {
-                    "data_path": "action_result.data.*.result.services.*.http.response.headers._encoding.Set_Cookie",
-                    "data_type": "string",
-                    "example_values": [
-                        "DISPLAY_UTF8"
-                    ]
-                },
-                {
                     "data_path": "action_result.data.*.result.services.*.http.response.headers._encoding.Vary",
                     "data_type": "string",
                     "example_values": [

--- a/censys.json
+++ b/censys.json
@@ -4294,5 +4294,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/censys_connector.py
+++ b/censys_connector.py
@@ -1,6 +1,6 @@
 # File: censys_connector.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/censys_consts.py
+++ b/censys_consts.py
@@ -1,6 +1,6 @@
 # File: censys_consts.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/censys_consts.py
+++ b/censys_consts.py
@@ -36,7 +36,7 @@ CENSYS_QUERY_HOSTS_DATASET = "hosts"
 
 # constants relating to "get_error_msg_from_exception"
 CENSYS_ERR_MSG_UNAVAILABLE = "Error message unavailable. Please check the asset configuration and|or action parameters"
-CENSYS_ERR_JSON_DECODE = "Unable to parse response as JSON: {} Raw text: {}"
+CENSYS_ERR_JSON_DECODE = "Unable to parse response as JSON: {}"
 
 # constants for integer validation
 CENSYS_INT_ERR_MSG = "Please provide a valid integer value in the {key}"

--- a/censys_rest.py
+++ b/censys_rest.py
@@ -15,7 +15,7 @@
 import phantom.app as phantom
 import requests
 
-from censys_consts import CENSYS_API_URL, CENSYS_ERR_JSON_DECODE, CENSYS_JSON_API_ID, CENSYS_JSON_SECRET
+from censys_consts import CENSYS_API_URL, CENSYS_DEFAULT_TIMEOUT, CENSYS_ERR_JSON_DECODE, CENSYS_JSON_API_ID, CENSYS_JSON_SECRET
 from censys_validation import get_error_message_from_exception
 
 
@@ -52,6 +52,7 @@ def make_rest_call(endpoint, action_result, config, data=None, method="post"):
             json=data,
             auth=(config[CENSYS_JSON_API_ID], config[CENSYS_JSON_SECRET]),
             headers=headers,
+            timeout=CENSYS_DEFAULT_TIMEOUT,
         )
     except Exception as e:
         return (

--- a/censys_rest.py
+++ b/censys_rest.py
@@ -46,7 +46,7 @@ def make_rest_call(endpoint, action_result, config, data=None, method="post"):
         resp_json = response.json()
     except Exception as e:
         return (
-            action_result.set_status(phantom.APP_ERROR, CENSYS_ERR_JSON_DECODE.format(e, response.text)),
+            action_result.set_status(phantom.APP_ERROR, CENSYS_ERR_JSON_DECODE.format(e)),
             {},
         )
 
@@ -64,7 +64,7 @@ def parse_http_error(action_result, r):
         resp_json = r.json()
     except Exception as e:
         return (
-            action_result.set_status(phantom.APP_ERROR, CENSYS_ERR_JSON_DECODE.format(e, r.text)),
+            action_result.set_status(phantom.APP_ERROR, CENSYS_ERR_JSON_DECODE.format(e)),
             None,
         )
 

--- a/censys_rest.py
+++ b/censys_rest.py
@@ -19,6 +19,29 @@ from censys_consts import CENSYS_API_URL, CENSYS_ERR_JSON_DECODE, CENSYS_JSON_AP
 from censys_validation import get_error_message_from_exception
 
 
+SENSITIVE_HTTP_HEADERS = {
+    "authorization",
+    "cookie",
+    "proxy_authorization",
+    "set_cookie",
+    "www_authenticate",
+}
+
+
+def redact_sensitive_headers(value, inside_headers=False):
+    if isinstance(value, dict):
+        cleaned = {}
+        for key, child in value.items():
+            normalized_key = str(key).casefold().replace("-", "_")
+            if inside_headers and normalized_key in SENSITIVE_HTTP_HEADERS:
+                continue
+            cleaned[key] = redact_sensitive_headers(child, inside_headers or normalized_key == "headers")
+        return cleaned
+    if isinstance(value, list):
+        return [redact_sensitive_headers(item, inside_headers) for item in value]
+    return value
+
+
 def make_rest_call(endpoint, action_result, config, data=None, method="post"):
     request_func = getattr(requests, method)
     headers = {"Content-type": "application/json", "Accept": "text/plain"}
@@ -53,7 +76,7 @@ def make_rest_call(endpoint, action_result, config, data=None, method="post"):
     if resp_json.get("status", "") == "error":
         return parse_http_error(action_result, response), {}
 
-    return phantom.APP_SUCCESS, resp_json
+    return phantom.APP_SUCCESS, redact_sensitive_headers(resp_json)
 
 
 def parse_http_error(action_result, r):

--- a/censys_rest.py
+++ b/censys_rest.py
@@ -63,7 +63,10 @@ def make_rest_call(endpoint, action_result, config, data=None, method="post"):
             {},
         )
 
-    if response.status_code not in (200, 429):
+    if response.status_code == 429:
+        return action_result.set_status(phantom.APP_ERROR, "Censys rate limit exceeded; retry later"), {}
+
+    if response.status_code != 200:
         return parse_http_error(action_result, response), {}
 
     try:
@@ -74,7 +77,8 @@ def make_rest_call(endpoint, action_result, config, data=None, method="post"):
             {},
         )
 
-    if resp_json.get("status", "") == "error":
+    api_code = resp_json.get("code")
+    if resp_json.get("status") == "error" or resp_json.get("error") or (isinstance(api_code, int) and not 200 <= api_code < 300):
         return parse_http_error(action_result, response), {}
 
     return phantom.APP_SUCCESS, redact_sensitive_headers(resp_json)
@@ -82,7 +86,7 @@ def make_rest_call(endpoint, action_result, config, data=None, method="post"):
 
 def parse_http_error(action_result, r):
     if "json" not in r.headers.get("Content-Type", ""):
-        return ""
+        return action_result.set_status(phantom.APP_ERROR, f"Censys returned HTTP status {r.status_code}")
 
     try:
         resp_json = r.json()
@@ -93,9 +97,9 @@ def parse_http_error(action_result, r):
         )
 
     message = "Server returned error with status: {}, Type: {}, Detail: {}".format(
-        resp_json.get("status", "NA"),
+        resp_json.get("code", resp_json.get("status", r.status_code)),
         resp_json.get("error_type", "NA"),
-        resp_json.get("error", "NA"),
+        resp_json.get("error", resp_json.get("detail", resp_json.get("message", "NA"))),
     )
 
     return action_result.set_status(phantom.APP_ERROR, message)

--- a/censys_rest.py
+++ b/censys_rest.py
@@ -1,6 +1,6 @@
 # File: censys_rest.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/censys_search.py
+++ b/censys_search.py
@@ -1,6 +1,6 @@
 # File: censys_search.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/censys_search.py
+++ b/censys_search.py
@@ -42,19 +42,27 @@ class CensysSearch:
         if phantom.is_fail(ret_val):
             return action_result.get_status(), None
 
-        hits = self._get_hits(response)
-        next = self._get_next(response)
+        hits = self._get_hits(response) or []
+        next_cursor = self._get_next(response) or ""
         total = self._get_total(response)
 
-        data_left = limit - len(hits)
-        while next != "" and data_left > 0:
-            ret_val, next_response = self._search_call(action_result, dataset, query, min(per_page, data_left), limit, next)
+        page_count = 1
+        max_pages = max(1, (limit + per_page - 1) // per_page)
+        while next_cursor and len(hits) < limit and page_count < max_pages:
+            requested_cursor = next_cursor
+            ret_val, next_response = self._search_call(action_result, dataset, query, min(per_page, limit - len(hits)), limit, requested_cursor)
             if phantom.is_fail(ret_val):
                 return action_result.get_status(), next_response
-            next_hits = self._get_hits(next_response)
+            next_hits = self._get_hits(next_response) or []
+            if not next_hits:
+                break
             hits.extend(next_hits)
-            next = self._get_next(next_response)
-            data_left -= len(next_hits)
+            page_count += 1
+            next_cursor = self._get_next(next_response) or ""
+            if next_cursor == requested_cursor:
+                break
+
+        hits = hits[:limit]
 
         for hit in hits:
             action_result.add_data(hit)

--- a/censys_validation.py
+++ b/censys_validation.py
@@ -1,6 +1,6 @@
 # File: censys_validation.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/censys_view.py
+++ b/censys_view.py
@@ -1,6 +1,6 @@
 # File: censys_view.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cs_cert_info.html
+++ b/cs_cert_info.html
@@ -11,7 +11,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!-- File: cs_cert_info.html
-  Copyright (c) 2016-2025 Splunk Inc.
+  Copyright (c) 2016-2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cs_cert_info.html
+++ b/cs_cert_info.html
@@ -95,7 +95,7 @@ and limitations under the License.
             </td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': ['sha256', 'hash'], 'value': '{{ result.param.sha256 }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': ['sha256', 'hash'], 'value': '{{ result.param.sha256|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.sha256 }}
                 &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
               </a>

--- a/cs_ip_domain_info.html
+++ b/cs_ip_domain_info.html
@@ -132,13 +132,7 @@ and limitations under the License.
             </tr>
           {% endif %}
         </table>
-        {% if result.message %}
-          <p>
-            {% autoescape off %}
-              {{ result.message }}
-            {% endautoescape %}
-          </p>
-        {% endif %}
+        {% if result.message %}<p>{{ result.message }}</p>{% endif %}
         {% if result.data.result.autonomous_system %}
           <h3 class="wf-h3-style">AS Info</h3>
           <table class="wf-table-vertical">

--- a/cs_ip_domain_info.html
+++ b/cs_ip_domain_info.html
@@ -102,7 +102,7 @@ and limitations under the License.
               </td>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['ip', 'ipv6'], 'value': '{{ result.param.ip }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['ip', 'ipv6'], 'value': '{{ result.param.ip|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.param.ip }}
                   &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                 </a>
@@ -116,7 +116,7 @@ and limitations under the License.
               </td>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ result.param.domain }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ result.param.domain|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.param.domain }}
                   &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                 </a>
@@ -303,7 +303,7 @@ and limitations under the License.
                       </td>
                       <td>
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['sha256'], 'value': '{{ result.data.ports|by_key:curr_port|by_key:curr_protocol|by_key:'tls'|by_key:'certificate'|by_key:'parsed'|by_key:'fingerprint_sha256' }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['sha256'], 'value': '{{ result.data.ports|by_key:curr_port|by_key:curr_protocol|by_key:'tls'|by_key:'certificate'|by_key:'parsed'|by_key:'fingerprint_sha256'|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ result.data.ports|by_key:curr_port|by_key:curr_protocol|by_key:'tls'|by_key:'certificate'|by_key:'parsed'|by_key:'fingerprint_sha256' }}
                           &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                         </a>

--- a/cs_ip_domain_info.html
+++ b/cs_ip_domain_info.html
@@ -11,7 +11,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!-- File: cs_ip_domain_info.html
-  Copyright (c) 2016-2025 Splunk Inc.
+  Copyright (c) 2016-2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,7 +1,7 @@
 **Unreleased**
 
-* - Escaped upstream action messages in the Censys widget and removed raw response bodies from JSON parsing errors.
-* - Escaped Censys widget values before embedding them in inline JavaScript contexts.
-* - Removed credential-bearing HTTP headers from Censys records before storing action-result data.
-* - Bounded Censys search pagination, stopped zero-progress cursors, truncated oversized pages, and added request timeouts.
-* - Reported Censys rate limits and v2 API error bodies as action failures instead of empty successful results.
+* Escaped upstream action messages in the Censys widget and removed raw response bodies from JSON parsing errors.
+* Escaped Censys widget values before embedding them in inline JavaScript contexts.
+* Removed credential-bearing HTTP headers from Censys records before storing action-result data.
+* Bounded Censys search pagination, stopped zero-progress cursors, truncated oversized pages, and added request timeouts.
+* Reported Censys rate limits and v2 API error bodies as action failures instead of empty successful results.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* - Escaped upstream action messages in the Censys widget and removed raw response bodies from JSON parsing errors.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * - Escaped upstream action messages in the Censys widget and removed raw response bodies from JSON parsing errors.
 * - Escaped Censys widget values before embedding them in inline JavaScript contexts.
+* - Removed credential-bearing HTTP headers from Censys records before storing action-result data.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 * - Escaped Censys widget values before embedding them in inline JavaScript contexts.
 * - Removed credential-bearing HTTP headers from Censys records before storing action-result data.
 * - Bounded Censys search pagination, stopped zero-progress cursors, truncated oversized pages, and added request timeouts.
+* - Reported Censys rate limits and v2 API error bodies as action failures instead of empty successful results.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * - Escaped upstream action messages in the Censys widget and removed raw response bodies from JSON parsing errors.
+* - Escaped Censys widget values before embedding them in inline JavaScript contexts.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * - Escaped upstream action messages in the Censys widget and removed raw response bodies from JSON parsing errors.
 * - Escaped Censys widget values before embedding them in inline JavaScript contexts.
 * - Removed credential-bearing HTTP headers from Censys records before storing action-result data.
+* - Bounded Censys search pagination, stopped zero-progress cursors, truncated oversized pages, and added request timeouts.


### PR DESCRIPTION
### Bug Fixes

- Escape upstream action messages and remove raw response bodies from JSON errors for PSAAS-30375.
- Escape widget values before embedding them in inline JavaScript for PSAAS-30832.
- Remove captured credential-bearing HTTP headers before persisting action results for PSAAS-31808.
- Bound cursor pagination, stop zero-progress pages, truncate oversized responses, and add request timeouts for PSAAS-31815.
- Treat Censys rate limits and v2 API error bodies as action failures for PSAAS-31819.

### Manual Documentation

- [x] I have verified that manual documentation has been updated where appropriate

### Other information

- Tracking Story: [PAPP-38109](https://splunk.atlassian.net/browse/PAPP-38109)
- Findings: [PSAAS-30375](https://splunk.atlassian.net/browse/PSAAS-30375), [PSAAS-30832](https://splunk.atlassian.net/browse/PSAAS-30832), [PSAAS-31808](https://splunk.atlassian.net/browse/PSAAS-31808), [PSAAS-31815](https://splunk.atlassian.net/browse/PSAAS-31815), [PSAAS-31819](https://splunk.atlassian.net/browse/PSAAS-31819)
- Local validation: full pre-commit suite and Python compile checks passed.
- This PR was created entirely with AI assistance. Written by Codex.

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!